### PR TITLE
Fix orientation for coronal and sagittal views

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -362,10 +362,8 @@ class DICOMViewer(QMainWindow):
                 arr = self.volume[self.current_index]
             elif self.view_axis == "coronal":
                 arr = self.volume[:, self.current_index, :]
-                arr = arr.T
             else:
                 arr = self.volume[:, :, self.current_index]
-                arr = arr.T
             qimg = numpy_to_qimage(arr)
             self.canvas.set_pixmap(QPixmap.fromImage(qimg))
             total = self.volume.shape[0] if self.view_axis == "axial" else (


### PR DESCRIPTION
## Summary
- Display coronal and sagittal slices without transposing them to avoid rotation and aspect distortion

## Testing
- `python -m py_compile Main.py`


------
https://chatgpt.com/codex/tasks/task_e_68c3dc1314ec83289fbfada619f21fb7