### PR TITLE
Add zoom functionality to view tab

### DIFF
--- a/canvas.py
+++ b/canvas.py
@@ -2,7 +2,11 @@
 
 from PyQt6.QtCore import Qt, QRectF
 from PyQt6.QtGui import QTransform, QPixmap, QPainter
-from PyQt6.QtWidgets import QGraphicsView, QGraphicsScene, QGraphicsPixmapItem
+from PyQt6.QtWidgets import (
+    QGraphicsView,
+    QGraphicsScene,
+    QGraphicsPixmapItem,
+)
 
 
 class ImageCanvas(QGraphicsView):
@@ -10,19 +14,41 @@ class ImageCanvas(QGraphicsView):
         super().__init__(parent)
         self.setScene(QGraphicsScene(self))
         self.pix_item = QGraphicsPixmapItem()
-        self.pix_item.setTransformationMode(Qt.TransformationMode.FastTransformation)
+        self.pix_item.setTransformationMode(
+            Qt.TransformationMode.FastTransformation
+        )
         self.scene().addItem(self.pix_item)
         self.setDragMode(QGraphicsView.DragMode.ScrollHandDrag)
         self.setRenderHint(QPainter.RenderHint.SmoothPixmapTransform, False)
+        self.setTransformationAnchor(
+            QGraphicsView.ViewportAnchor.AnchorUnderMouse
+        )
+        self._zoom = 1.0
 
-    def set_pixmap(self, pm: QPixmap):
+    def set_pixmap(self, pm: QPixmap, reset: bool = True):
         self.scene().setSceneRect(QRectF(pm.rect()))
         self.pix_item.setPixmap(pm)
-        self.reset_view()
+        if reset:
+            self.reset_view()
 
     def reset_view(self):
+        self._zoom = 1.0
         self.setTransform(QTransform())
         scene_rect = self.sceneRect()
         view_rect = self.viewport().rect()
         if scene_rect.width() > view_rect.width() or scene_rect.height() > view_rect.height():
             self.fitInView(scene_rect, Qt.AspectRatioMode.KeepAspectRatio)
+
+    def wheelEvent(self, event):
+        factor = 1.25 if event.angleDelta().y() > 0 else 0.8
+        self._apply_zoom(factor)
+
+    def zoom_in(self):
+        self._apply_zoom(1.25)
+
+    def zoom_out(self):
+        self._apply_zoom(0.8)
+
+    def _apply_zoom(self, factor: float):
+        self.scale(factor, factor)
+        self._zoom *= factor

--- a/viewer.py
+++ b/viewer.py
@@ -154,6 +154,16 @@ class DICOMViewer(QMainWindow):
         self.act_next.triggered.connect(self.next_slice)
         tb.addAction(self.act_next)
 
+        self.act_zoom_in = QAction("Zoom +", self)
+        self.act_zoom_in.setShortcut(QKeySequence("+"))
+        self.act_zoom_in.triggered.connect(self.canvas.zoom_in)
+        tb.addAction(self.act_zoom_in)
+
+        self.act_zoom_out = QAction("Zoom -", self)
+        self.act_zoom_out.setShortcut(QKeySequence("-"))
+        self.act_zoom_out.triggered.connect(self.canvas.zoom_out)
+        tb.addAction(self.act_zoom_out)
+
         self.sep_before_axis = tb.addSeparator()
 
         self.axis_combo = QComboBox()
@@ -172,6 +182,8 @@ class DICOMViewer(QMainWindow):
         show_view = is_view
         self.act_prev.setVisible(show_view)
         self.act_next.setVisible(show_view)
+        self.act_zoom_in.setVisible(show_view)
+        self.act_zoom_out.setVisible(show_view)
         self.sep_before_axis.setVisible(show_view and self.series_is_3d)
         self.axis_combo.setVisible(show_view and self.series_is_3d)
 
@@ -250,12 +262,12 @@ class DICOMViewer(QMainWindow):
                 continue
         self.volume = np.stack(vol, axis=0) if vol else None
         self._update_slider_range()
-        self.display_current()
+        self.display_current(reset_view=True)
 
     # -----------------------------------------------------------------
     # Display
     # -----------------------------------------------------------------
-    def display_current(self):
+    def display_current(self, reset_view: bool = False):
         if self.volume is None:
             return
         try:
@@ -266,7 +278,7 @@ class DICOMViewer(QMainWindow):
             else:
                 arr = self.volume[:, :, self.current_index]
             qimg = numpy_to_qimage(arr)
-            self.canvas.set_pixmap(QPixmap.fromImage(qimg))
+            self.canvas.set_pixmap(QPixmap.fromImage(qimg), reset=reset_view)
             total = (
                 self.volume.shape[0]
                 if self.view_axis == "axial"
@@ -332,7 +344,7 @@ class DICOMViewer(QMainWindow):
         self.view_axis = text.lower()
         self.current_index = 0
         self._update_slider_range()
-        self.display_current()
+        self.display_current(reset_view=True)
 
     def _update_slider_range(self):
         if self.volume is None:


### PR DESCRIPTION
## Summary
- Enable zooming in the viewer with mouse wheel and dedicated toolbar actions
- Preserve zoom level between slice changes with reset control

## Testing
- `python -m py_compile viewer.py canvas.py`


------
https://chatgpt.com/codex/tasks/task_e_68c7bd6a72848328b68bf95113c25df5