### PR TITLE
Show view selector only for 3D series in View tab

### DIFF
--- a/sidebar.py
+++ b/sidebar.py
@@ -1,6 +1,6 @@
 from PyQt6.QtCore import Qt, QSize
 from PyQt6.QtGui import QAction, QKeySequence
-from PyQt6.QtWidgets import QToolBar, QComboBox
+from PyQt6.QtWidgets import QToolBar
 
 
 class Sidebar:
@@ -39,17 +39,10 @@ class Sidebar:
         self.act_zoom_out.triggered.connect(canvas.zoom_out)
         tb.addAction(self.act_zoom_out)
 
-        self.sep_before_axis = tb.addSeparator()
-
-        self.axis_combo = QComboBox()
-        self.axis_combo.addItems(["Axial", "Coronal", "Sagittal"])
-        self.axis_combo.currentTextChanged.connect(parent.change_orientation)
-        tb.addWidget(self.axis_combo)
-
         self.toolbar = tb
 
-    def update_visibility(self, is_data: bool, is_view: bool, show_axis: bool):
-        """Show or hide actions based on current tab and data."""
+    def update_visibility(self, is_data: bool, is_view: bool):
+        """Show or hide actions based on current tab."""
         self.act_open.setVisible(is_data)
         self.sep_after_open.setVisible(is_data)
 
@@ -57,5 +50,3 @@ class Sidebar:
         self.act_next.setVisible(is_view)
         self.act_zoom_in.setVisible(is_view)
         self.act_zoom_out.setVisible(is_view)
-        self.sep_before_axis.setVisible(is_view and show_axis)
-        self.axis_combo.setVisible(is_view and show_axis)

--- a/tabs.py
+++ b/tabs.py
@@ -6,6 +6,7 @@ from PyQt6.QtWidgets import (
     QSlider,
     QPushButton,
     QTabWidget,
+    QComboBox,
 )
 
 
@@ -21,10 +22,15 @@ class ViewerTabs:
 
         self.slice_slider = QSlider(Qt.Orientation.Horizontal)
         self.slice_slider.valueChanged.connect(parent.on_slider_changed)
+        self.axis_combo = QComboBox()
+        self.axis_combo.addItems(["Axial", "Coronal", "Sagittal"])
+        self.axis_combo.currentTextChanged.connect(parent.change_orientation)
+        self.axis_combo.setVisible(False)
         view_tab = QWidget()
         view_layout = QVBoxLayout(view_tab)
         view_layout.addWidget(canvas)
         view_layout.addWidget(self.slice_slider)
+        view_layout.addWidget(self.axis_combo)
 
         self.normalize_button = QPushButton("Normalize Intensity")
         self.normalize_button.clicked.connect(parent.normalize_volume)

--- a/viewer.py
+++ b/viewer.py
@@ -96,7 +96,8 @@ class DICOMViewer(QMainWindow):
         current = self.tab_widget.currentIndex()
         is_data = current == 0
         is_view = current == 1
-        self.sidebar.update_visibility(is_data, is_view, self.series_is_3d)
+        self.sidebar.update_visibility(is_data, is_view)
+        self.tabs.axis_combo.setVisible(is_view and self.series_is_3d)
 
     # -----------------------------------------------------------------
     # File loading
@@ -132,7 +133,7 @@ class DICOMViewer(QMainWindow):
         self.current_index = 0
 
         self.series_is_3d = "3d" in current.text().lower()
-        self.sidebar.axis_combo.setCurrentIndex(0)
+        self.tabs.axis_combo.setCurrentIndex(0)
         self.view_axis = "axial"
         self.update_toolbar_visibility()
 


### PR DESCRIPTION
## Summary
- Move view selector dropdown from sidebar into the View tab
- Display selector only when a 3D series is loaded and the View tab is active

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c7da2666308328b4289a7079dd1816